### PR TITLE
Fix wrong types in UART interface

### DIFF
--- a/lib/UART-Arduino/UART-Arduino.cpp
+++ b/lib/UART-Arduino/UART-Arduino.cpp
@@ -7,19 +7,19 @@ UART_Arduino::UART_Arduino(HardwareSerial& serial)
     _serial.setTimeout(_timeout);
 }
 
-bool UART_Arduino::begin(uint64_t baud)
+bool UART_Arduino::begin(uint32_t baud)
 {
     _serial.begin(baud);
     return true;
 }
 
-void UART_Arduino::setTimeout(uint64_t timeout)
+void UART_Arduino::setTimeout(uint32_t timeout)
 {
     UART_Interface::setTimeout(timeout);
     _serial.setTimeout(timeout);
 }
 
-uint64_t UART_Arduino::getTimeout(void) const
+uint32_t UART_Arduino::getTimeout(void) const
 {
     return UART_Interface::getTimeout();
 }

--- a/lib/UART-Arduino/UART-Arduino.hpp
+++ b/lib/UART-Arduino/UART-Arduino.hpp
@@ -11,9 +11,9 @@ private:
 public:
     UART_Arduino(HardwareSerial& serial);
 
-    bool begin(uint64_t baud) override;
-    void setTimeout(uint64_t timeout) override;
-    uint64_t getTimeout(void) const override;
+    bool begin(uint32_t baud) override;
+    void setTimeout(uint32_t timeout) override;
+    uint32_t getTimeout(void) const override;
     bool write(uint8_t byte) override;
     size_t writeBytes(const uint8_t *bytes, size_t len) override;
     size_t available(void) override;

--- a/lib/UART-Interface/UART-Interface.hpp
+++ b/lib/UART-Interface/UART-Interface.hpp
@@ -8,12 +8,12 @@ class UART_Interface
 private:
 
 protected:
-    uint64_t _timeout = 1000;   // 1000ms default
+    uint32_t _timeout = 1000;   // 1000ms default
 
 public:
-    virtual bool begin(uint64_t baud) = 0;     // Should return true, if begin is succesful
-    virtual void setTimeout(uint64_t timeout) {_timeout = timeout;}
-    virtual uint64_t getTimeout(void) const {return _timeout;}
+    virtual bool begin(uint32_t baud) = 0;     // Should return true, if begin is succesful
+    virtual void setTimeout(uint32_t timeout) {_timeout = timeout;}
+    virtual uint32_t getTimeout(void) const {return _timeout;}
     virtual bool write(uint8_t byte) = 0;           // Should return true, if byte written
     virtual size_t writeBytes(const uint8_t *bytes, size_t len) = 0;    // Should return number of bytes written
     virtual size_t available(void) = 0;             // Should return number of bytes available for reading, 0 if none available


### PR DESCRIPTION
`unsigned long` is not the same size on different systems...
On arduino `unsigned long` = `uint32_t`.

By mistake i had used `uint64_t`, this is what has been corrected.

## Functions changed in UART interface classes and implementations:
`void begin(uint32_t baud)`
`void setTimeout(uint32_t timeout)`
`uint32_t getTimeout(void)`

## Variables changed:
`uint32_t _timeout`